### PR TITLE
build(package.json): remove single quotes in watch:bdd task

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "scripts": {
     "test": "npx bddgen && npx playwright test",
-    "watch:bdd": "nodemon -w ./features -w ./steps -e feature,js,ts --exec 'npx bddgen'",
+    "watch:bdd": "nodemon -w ./features -w ./steps -e feature,js,ts --exec npx bddgen",
     "watch:pw": "playwright test --ui",
     "watch": "run-p watch:*"
   },


### PR DESCRIPTION
Fix bug: [nodemon] starting `'npx bddgen'`