### PR TITLE
added proof of bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "playwright-bdd-example",
   "version": "0.1.0",
   "scripts": {
-    "test": "npx bddgen && npx playwright test",
+    "test": "npx bddgen && npx playwright test --shard 2/2",
+    "merge-report": "npx playwright merge-reports --config playwright.config.ts ./output/blob-report",
     "report": "npx http-server ./cucumber-report -c-1 -a localhost -o index.html",
     "watch:bdd": "nodemon -w ./features -e feature,js,ts --exec \"npx bddgen\"",
     "watch:pw": "playwright test --ui",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -27,6 +27,8 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
+      testDir: defineBddConfig({outputDir: "some_other_folder",  features: 'features/*.feature',
+        steps: 'features/steps/*.ts'}),
       use: { ...devices['Desktop Chrome'] },
     },
   ],


### PR DESCRIPTION
Here is the proof: running both tests using shards, with features being generated in another folder than standard produces an empty []